### PR TITLE
allow to explicitly set SSL on SMTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,16 @@ The option `timeout` determines how long to consider a service healthy after a s
 Email notifications are optional but recommended for receiving health reports. Configure the email section in the config file with your SMTP server details. You can find many SMTP providers online, both paid and free.
 
 
-| Field          | Description                                         | Required | Example                         |
-|----------------|-----------------------------------------------------|----------|---------------------------------|
-| `smtp_server`  | Address of the SMTP server                          | Yes      | `smtp.gmail.com`               |
-| `smtp_port`    | SMTP port                                           | Yes      | `587`                          |
-| `smtp_username`| SMTP server username                                | Yes      | `your-email@gmail.com`         |
-| `smtp_password`| SMTP server password                                | Yes      | `your-password`                |
-| `send_to`      | Recipient email address                             | Yes      | `your-email@gmail.com`         |
-| `sender`       | Email address used as the sender                   | Yes      | `beacon@example.com`           |
-| `prefix`       | String prepended to email subject for easy filtering | No       | `[Production]`                 |
+| Field          | Description                                          | Required | Example                         |
+|----------------|------------------------------------------------------|----------|---------------------------------|
+| `smtp_server`  | Address of the SMTP server                           | Yes      | `smtp.gmail.com`                |
+| `smtp_port`    | SMTP port                                            | Yes      | `587`                           |
+| `smtp_username`| SMTP server username                                 | Yes      | `your-email@gmail.com`          |
+| `smtp_password`| SMTP server password                                 | Yes      | `your-password`                 |
+| `smtp_ssl`     | Explicitly set network SSL for the `go-mail` client  | No       | `true`                          |
+| `send_to`      | Recipient email address                              | Yes      | `your-email@gmail.com`          |
+| `sender`       | Email address used as the sender                     | Yes      | `beacon@example.com`            |
+| `prefix`       | String prepended to email subject for easy filtering | No       | `[Production]`                  |
 
 Example:
 ```yaml

--- a/conf/config.go
+++ b/conf/config.go
@@ -49,9 +49,12 @@ type EmailConfig struct {
 	SmtpPort     int    `yaml:"smtp_port" env:"SMTP_PORT"`
 	SmtpUsername string `yaml:"smtp_username" env:"SMTP_USERNAME"`
 	SmtpPassword Secret `yaml:"smtp_password" envPrefix:"SMTP_PASSWORD"`
-	SendTo       string `yaml:"send_to" env:"SEND_TO"`
-	Sender       string `yaml:"sender" env:"SENDER"`
-	Prefix       string `yaml:"prefix" env:"PREFIX"`
+	// If true, then explicitly set the network
+	// SSL option for the SMTP client.
+	SmtpSSL bool   `yaml:"smtp_ssl" env:"smtp_SSL"`
+	SendTo  string `yaml:"send_to" env:"SEND_TO"`
+	Sender  string `yaml:"sender" env:"SENDER"`
+	Prefix  string `yaml:"prefix" env:"PREFIX"`
 	// not bool to allow more flexible usage
 	Enabled string `yaml:"enabled" env:"ENABLED"`
 	// "never", "beacon", "allow"

--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -121,6 +121,7 @@ smtp_server: mail.smtp2go.com
 smtp_port: 587
 smtp_username: beacon
 smtp_password: h4xor
+smtp_ssl: true
 send_to: you@example.fake
 sender: noreply@example.fake
 prefix: "[test]"
@@ -136,9 +137,40 @@ prefix: "[test]"
 		587,
 		"beacon",
 		Secret{"h4xor", ""},
+		true,
 		"you@example.fake",
 		"noreply@example.fake",
 		"[test]",
+		"",
+		"",
+	})
+	require.Equal(t, "h4xor", emailConfig.SmtpPassword.Get())
+}
+
+func TestParseEmailConfigOptionals(t *testing.T) {
+	src := `
+smtp_server: mail.smtp2go.com
+smtp_port: 587
+smtp_username: beacon
+smtp_password: h4xor
+send_to: you@example.fake
+sender: noreply@example.fake
+`
+	emailConfig := EmailConfig{}
+	err := yaml.Unmarshal([]byte(src), &emailConfig)
+	require.NoError(t, err)
+	t.Logf("%#v\n", emailConfig)
+	require.NotContains(t, fmt.Sprintf("%#v", emailConfig), "h4xor",
+		"Password (secret) value should not be logged")
+	require.Equal(t, emailConfig, EmailConfig{
+		"mail.smtp2go.com",
+		587,
+		"beacon",
+		Secret{"h4xor", ""},
+		false, // optional SSL
+		"you@example.fake",
+		"noreply@example.fake",
+		"", // optional prefix
 		"",
 		"",
 	})

--- a/handlers/mail.go
+++ b/handlers/mail.go
@@ -86,6 +86,10 @@ func SendMail(emailConfig *conf.EmailConfig, subject string, body string) error 
 		})
 	}
 
+	if emailConfig.SmtpSSL {
+		client.SetSSL(true)
+	}
+
 	err = client.DialAndSend(message)
 
 	if err != nil {


### PR DESCRIPTION
I was trying to make sending email work using the [following SMTP provider](https://o-seznam.cz/napoveda/email/mohlo-by-se-hodit/postovni-programy-a-aplikace/). However, I was receiving error `dial failed: EOF`, with no more information.

Tinkering with the email client, I found out that either using port 25 works (even with strict TLS config enabled), but the communication is over naked SMTP (which later uses STARTTLS). I think the intended way with my provider is to use SSL/TLS in the network communication also, and this should be a way to force it. Using this SSL option works with the port 465 (which the SMTP provider recommends).

To be sure nothing breaks, I added a test for serialization, which tests that the default values have expected defaults, so the change is not breaking.